### PR TITLE
Corrected chmod in vault Dockerfile

### DIFF
--- a/vault/Dockerfile
+++ b/vault/Dockerfile
@@ -17,7 +17,7 @@ RUN apk --no-cache add \
 RUN wget --quiet --output-document=/tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
     unzip /tmp/vault.zip -d /vault && \
     rm -f /tmp/vault.zip && \
-    chmod +x /vault
+    chmod +x /vault/vault
 
 # update PATH
 ENV PATH="PATH=$PATH:$PWD/vault"


### PR DESCRIPTION
/vault is a directory, causing `chmod +x /vault` to fail. Instead, it should be `chmod +x /vault/vault`