### PR TITLE
fix: error "failed to check for initialization"

### DIFF
--- a/vault/config/vault-config.json
+++ b/vault/config/vault-config.json
@@ -2,7 +2,7 @@
   "backend": {
     "consul": {
       "address": "consul:8500",
-      "path": "vault/"
+      "path": "/vault/"
     }
   },
   "listener": {


### PR DESCRIPTION
"failed to check for initialization: open vault/data/core: not a directory"

predending a "/" makes that error go away